### PR TITLE
ZipFileEnrichStrategy - PoolEnrich - if newExchange is null, it means there's no remote file to consume

### DIFF
--- a/enrich/src/main/java/org/assimbly/enrich/zipfile/ZipFileEnrichStrategy.java
+++ b/enrich/src/main/java/org/assimbly/enrich/zipfile/ZipFileEnrichStrategy.java
@@ -26,6 +26,11 @@ public class ZipFileEnrichStrategy implements AggregationStrategy {
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
         element_names = new ArrayList<>();
 
+        if (newExchange == null) {
+            // there’s no remote file to consume
+            return oldExchange;
+        }
+
         Message in = oldExchange.getIn();
         Message resource = newExchange.getIn();
 


### PR DESCRIPTION
> First, you check whether any data was consumed. If newExchange is null, there’s no remote file to consume, and you just return the existing data.

https://livebook.manning.com/book/camel-in-action-second-edition/chapter-3/117