### PR TITLE
JsonToXml legacy component - TransformerFactory + self-closing tags

### DIFF
--- a/jsontoxmllegacy/src/main/java/org/assimbly/jsontoxmllegacy/JsonToXmlProcessor.java
+++ b/jsontoxmllegacy/src/main/java/org/assimbly/jsontoxmllegacy/JsonToXmlProcessor.java
@@ -47,13 +47,16 @@ public class JsonToXmlProcessor implements Processor {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance(
-                "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl",
+                "net.sf.saxon.TransformerFactoryImpl",
                 null
         );
         Transformer transformer = transformerFactory.newTransformer();
         StringWriter writer = new StringWriter();
         transformer.transform(new DOMSource(document), new StreamResult(writer));
         String xmlContent = writer.toString();
+
+        // post-processing to convert self-closing tags to <tag></tag>
+        xmlContent = xmlContent.replaceAll("<(\\w+)([^>]*)/>", "<$1$2></$1>");
 
         setContent(exchange, xmlContent);
     }


### PR DESCRIPTION
- force TransformerFactory net.sf.saxon.TransformerFactoryImpl - is the one that most resembles the old structure
- convert self-closing tags to <tag></tag>